### PR TITLE
Add support for template variables + handle timestamp stored as string

### DIFF
--- a/couchbase-datasource/pkg/plugin/plugin.go
+++ b/couchbase-datasource/pkg/plugin/plugin.go
@@ -185,8 +185,8 @@ func (d *CouchbaseDatasource) query(channel *string, query_data *QueryRequest) b
 				return response
 			}
 			timeField = &match[timeRg.SubexpIndex("field")]
-			query_string = timeRg.ReplaceAllString(query_string, fmt.Sprintf("$1 > STR_TO_MILLIS('%s') AND $1 <= STR_TO_MILLIS('%s')", tr.From.Format(time.RFC3339), tr.To.Format(time.RFC3339)))
-			query_string = "SELECT * FROM (" + query_string + ") AS data ORDER by data." + *timeField + " ASC"
+			query_string = timeRg.ReplaceAllString(query_string, fmt.Sprintf("TO_NUMBER($1) > STR_TO_MILLIS('%s') AND TO_NUMBER($1) <= STR_TO_MILLIS('%s')", tr.From.Format(time.RFC3339), tr.To.Format(time.RFC3339)))
+			query_string = "SELECT * FROM (" + query_string + ") AS data ORDER by TO_NUMBER(data." + *timeField + ") ASC"
 		}
 	}
 

--- a/couchbase-datasource/pkg/plugin/plugin.go
+++ b/couchbase-datasource/pkg/plugin/plugin.go
@@ -191,7 +191,7 @@ func (d *CouchbaseDatasource) query(channel *string, query_data *QueryRequest) b
 	}
 
 	if timeField == nil {
-		response.Error = errors.New("Failed to detect time field. Pleae use time_range(fieldName) or str_time_range(fieldName) functions in WHERE clause of your query.")
+		response.Error = errors.New("Failed to detect time field. Please use time_range(fieldName) or str_time_range(fieldName) functions in WHERE clause of your query.")
 		return response
 	}
 

--- a/couchbase-datasource/src/datasource.ts
+++ b/couchbase-datasource/src/datasource.ts
@@ -1,10 +1,18 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { CouchbaseOptions, CouchbaseQuery } from './types';
 
 export class Couchbase extends DataSourceWithBackend<CouchbaseQuery, CouchbaseOptions> {
   annotations = {};
   constructor(instanceSettings: DataSourceInstanceSettings<CouchbaseOptions>) {
     super(instanceSettings);
+  }
+
+  // Support template variables
+  applyTemplateVariables(query: CouchbaseQuery, scopedVars: ScopedVars) {
+    return {
+      ...query,
+      query: getTemplateSrv().replace(query.query, scopedVars)
+    };
   }
 }


### PR DESCRIPTION
This should fix #12 and handle DB who store the timestamp as a string.